### PR TITLE
download stopwords if not present

### DIFF
--- a/text-summarizer.py
+++ b/text-summarizer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import nltk
+nltk.download("stopwords")
 from nltk.corpus import stopwords
 from nltk.cluster.util import cosine_distance
 import numpy as np

--- a/text-summarizer.py
+++ b/text-summarizer.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 import nltk
-nltk.download("stopwords")
 from nltk.corpus import stopwords
 from nltk.cluster.util import cosine_distance
 import numpy as np
@@ -60,6 +59,7 @@ def build_similarity_matrix(sentences, stop_words):
 
 
 def generate_summary(file_name, top_n=5):
+    nltk.download("stopwords")
     stop_words = stopwords.words('english')
     summarize_text = []
 


### PR DESCRIPTION
When I have tried to run the file it showed  an error: 
Resource "stopwords" not found.
Attempted to load corpora/stopwords

  Searched in:
    - '/home/main/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'

This was because I have not used nltk module before and thats y never downloaded stopwords. So I have added the lines for importing these stopwords. 